### PR TITLE
Fixed bug in Quill dependency check causing the plugin to always self-disable

### DIFF
--- a/src/main/java/me/levitate/quill/injection/QuillPlugin.java
+++ b/src/main/java/me/levitate/quill/injection/QuillPlugin.java
@@ -2,7 +2,6 @@ package me.levitate.quill.injection;
 
 import co.aikar.commands.BaseCommand;
 import lombok.Getter;
-import me.levitate.quill.Quill;
 import me.levitate.quill.injection.annotation.Module;
 import me.levitate.quill.injection.container.DependencyContainer;
 import me.levitate.quill.injection.exception.DependencyException;
@@ -36,7 +35,7 @@ public abstract class QuillPlugin extends JavaPlugin {
         try {
             // Initialize container
             Plugin quillPlugin = getServer().getPluginManager().getPlugin("Quill");
-            if (!(quillPlugin instanceof Quill)) {
+            if (quillPlugin == null) {
                 getLogger().severe("Quill plugin not found! Make sure it's installed.");
                 getServer().getPluginManager().disablePlugin(this);
                 return;


### PR DESCRIPTION
Fixed a bug where the plugin disabled itself incorrectly. The check `quillPlugin instanceof Quill` always failed because getPlugin() returns a generic Plugin, not a specific class. Updated to check for `quillPlugin == null` instead, to properly detect if Quill is missing.


![grafik](https://github.com/user-attachments/assets/52ee6e46-368c-4d7c-b033-366e7a24b22d)
